### PR TITLE
Use the relative numbers in the sidebar with soft-wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
                 \ '',
                 \ '',
                 \ ]
-
+    
     " <-------------------------- Plugins Setting ------------------------->
 
 <hr/>
@@ -92,6 +92,9 @@ surroundings in pairs</code><br/>
 ## Code Completion
 ### [YouCompleteMe](https://github.com/Valloric/YouCompleteMe)
 --> <code>A code-completion engine for Vim </code><br/>
+
+--> [Answer for this error](https://neovim.io/doc/user/provider.html): <code>YouCompleteMe unavailable: requires Vim compiled with Python (2.6+ or 3.3+) support</code>
+
 --> **zip size**: 279KB<br/>
 
 ### [NeoComplete](https://github.com/Shougo/neocomplete.vim)

--- a/init.vim
+++ b/init.vim
@@ -72,6 +72,9 @@ map <Leader>m <esc>:tabnext<CR>
 vnoremap < <gv
 vnoremap > >gv
 
+noremap <silent> <expr> j (v:count == 0 ? 'gj' : 'j')
+noremap <silent> <expr> k (v:count == 0 ? 'gk' : 'k')
+
 " <---------------------------  Color Theme --------------------------->
 set background=dark
 color molokai
@@ -95,8 +98,8 @@ set number                                               " show line num
 set numberwidth=1                                         " number width
 set relativenumber
 set tw=80                               " width of document (used by gd)
-set nowrap                            " don't automatically wrap on load
-set fo-=t                    " don't automatically wrap text when typing
+set wrap                            " don't automatically wrap on load
+"set fo-=t                    " don't automatically wrap text when typing
 set colorcolumn=80
 highlight ColorColumn ctermbg=233
 


### PR DESCRIPTION
The often used option below will break the `<vcount>` functionality, if you have lines in your text, which span across multiple lines.

```
noremap j gj
noremap k gk
```

so we choose the option below to use `:relativenumber` and `:set wrap`

```
nnoremap <expr> k (v:count == 0 ? 'gk' : 'k')
nnoremap <expr> j (v:count == 0 ? 'gj' : 'j')
```

More details [Here](http://stackoverflow.com/questions/20975928/moving-the-cursor-through-long-soft-wrapped-lines-in-vim/21000307#21000307)
